### PR TITLE
Fix minimum nominator stake validation logic

### DIFF
--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -97,10 +97,14 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
     if (!canExecuteWithdrawal || !validationResult.isValid) return;
 
     try {
+      // Check if this should be treated as a full withdrawal
+      const isEffectivelyFullWithdrawal =
+        withdrawalMethod === 'all' || validationResult.willWithdrawAll;
+
       await executeWithdraw({
         operatorId: position.operatorId,
-        amount: withdrawalMethod === 'all' ? undefined : withdrawalPreview.netStakeWithdrawal,
-        withdrawalType: withdrawalMethod,
+        amount: isEffectivelyFullWithdrawal ? undefined : withdrawalPreview.netStakeWithdrawal,
+        withdrawalType: isEffectivelyFullWithdrawal ? 'all' : 'partial',
       });
     } catch (error) {
       console.error('Withdrawal failed:', error);

--- a/apps/web/src/lib/staking-utils.ts
+++ b/apps/web/src/lib/staking-utils.ts
@@ -1,5 +1,6 @@
 import type { StakingCalculations, StakingValidation } from '@/types/staking';
 import type { Operator } from '@/types/operator';
+import type { UserPosition } from '@/types/position';
 
 export const TRANSACTION_FEE = 0.0001; // Fallback fee
 const STORAGE_FUND_PERCENTAGE = 0.2; // 20%
@@ -24,9 +25,14 @@ export const calculateStakingAmounts = (
 export const getValidationRules = (
   operator: Operator,
   availableBalance: number,
+  currentPosition?: UserPosition | null,
 ): StakingValidation => {
+  // Only enforce minimum on first nomination (when user has no current position)
+  const hasExistingPosition = currentPosition && currentPosition.positionValue > 0;
+  const effectiveMinimum = hasExistingPosition ? 0 : parseFloat(operator.minimumNominatorStake);
+
   return {
-    minimum: parseFloat(operator.minimumNominatorStake), // Already in AI3 format
+    minimum: effectiveMinimum,
     maximum: availableBalance,
     required: true,
     decimals: 8,
@@ -53,8 +59,9 @@ export const validateStakingAmount = (
     return { isValid: false, errors };
   }
 
-  if (numericAmount < validation.minimum) {
-    errors.push(`Amount must be at least ${validation.minimum} AI3`);
+  // Only enforce minimum if it's greater than 0 (first nomination)
+  if (validation.minimum > 0 && numericAmount < validation.minimum) {
+    errors.push(`First nomination must be at least ${validation.minimum} AI3`);
   }
 
   if (numericAmount > validation.maximum) {


### PR DESCRIPTION
## Summary
Fixes the minimum nominator stake validation logic in the staking UI as described in issue #54.

## Problem
- Nomination validation was too restrictive, requiring minimum stake for ALL nominations
- Withdrawal validation was too permissive, with no warnings about forced full withdrawals

## Solution
- ✅ Only enforce minimum stake on first nomination (when user has zero shares)
- ✅ Allow any amount > 0 for subsequent nominations when user has existing position
- ✅ Add withdrawal validation to detect and warn about forced full withdrawals
- ✅ Improve user feedback with clear validation messages and warnings

## Changes Made
1. **Updated staking validation logic** (`staking-utils.ts`)
2. **Added withdrawal validation** (`withdrawal-utils.ts`)
3. **Enhanced StakingForm** (`StakingForm.tsx`)
4. **Enhanced WithdrawalForm** (`WithdrawalForm.tsx`)

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint validation passes
- ✅ No breaking changes

Fixes #54